### PR TITLE
feat(llm): prioritize cross-media coverage in topic clustering

### DIFF
--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -101,9 +101,15 @@ export async function clusterNews(articles: NewsItem[]): Promise<NewsCluster[]> 
     1. Group articles that report on the EXACT SAME event or issue.
     2. Ignore generic or standalone articles that don't have related coverage.
     3. Each cluster must have at least 2 articles.
-    4. Limit to top 15 most significant topics.
-    5. Output MUST be in Traditional Chinese (Taiwan).
-    6. Return the result in this JSON format:
+
+    **CRITICAL RANKING INSTRUCTIONS:**
+    4. **Prioritize Cross-Media Coverage:** You MUST rank topics that are covered by **MULTIPLE DISTINCT NEWS SOURCES** (e.g., PTS, UDN, LTN all reporting on it) HIGHER than topics covered by only one source.
+    5. **Handle Special Reports:** If a topic has many articles but they all come from a **SINGLE SOURCE** (e.g., only UDN reports 5 times), this is a "Special Report". Rank these LOWER than multi-source Hot Topics, unless the event is significantly major.
+    6. **Sort Order:** The output array MUST be sorted by importance: Cross-media "Hot Topics" first, followed by significant single-source "Special Reports".
+
+    7. Limit to top 15 most significant topics.
+    8. Output MUST be in Traditional Chinese (Taiwan).
+    9. Return the result in this JSON format:
     [
       {
         "topic": "Concise Topic Name (Traditional Chinese)",


### PR DESCRIPTION
### 💡 改進內容
優化了新聞分群的 Prompt 邏輯，主要針對「熱門焦點」的認定進行了權重調整：

1. **跨媒體優先**：強制要求 AI 將多個不同媒體來源（如公視、聯合、自由）共同報導的主題排在最前面。
2. **區分專題報導**：若某個主題文章數雖多但來源單一（例如單一媒體的專題報導），將其排序往後調整，但仍保留其重要性。
3. **優化排序邏輯**：讓首頁呈現的新聞更具社會公信力與平衡感。

### 🧪 驗證結果
已使用模擬數據驗證，在同樣文章數的情況下，3 個來源的主題會排在 1 個來源的專題前面。